### PR TITLE
Add namespace to generated item id

### DIFF
--- a/src/modules/ItemPackageBuilder.mjs
+++ b/src/modules/ItemPackageBuilder.mjs
@@ -441,7 +441,7 @@ export class ItemPackageBuilder {
     }
 
     itemPackage.items.add({
-      id: `${equipment.localID}_${rarity.name}_${index}`,
+      id: `${equipment.localID}_${equipment.namespace}_${rarity.name}_${index}`,
       itemType: 'Equipment',
       name: variant.name,
       // customDescription: equipment._customDescription,


### PR DESCRIPTION
Fix issue with the same item id from different namespaces.
Issue was observed with Elder scroll mod since it had "Jester Hat" same as base game